### PR TITLE
patchtable: replace dead database.turtle-wow.org with new URL

### DIFF
--- a/patchtable.lua
+++ b/patchtable.lua
@@ -56,7 +56,7 @@ if pfDB.bitraces then
 end
 
 -- Use turtle-wow database url
-pfQuest.dburl = "https://database.turtle-wow.org/?quest="
+pfQuest.dburl = "https://database.turtlecraft.gg/?quest="
 
 -- Disable Minimap in custom dungeon maps
 function pfMap:HasMinimap(map_id)


### PR DESCRIPTION
The old database URL `https://database.turtle-wow.org/` is no longer accessible.
TurtleWoW has moved their database to a new address.

This PR updates `pfQuest.dburl` in `patchtable.lua` to point to the new working URL,
so the [?] button in the quest log opens the correct database page again.

Before: https://database.turtle-wow.org/?quest=
After:  https://database.turtlecraft.gg/?quest=

You can verify the new URL works by opening it in a browser
verify https://database.turtlecraft.gg/?quest=954
<img width="966" height="815" alt="change_url" src="https://github.com/user-attachments/assets/88035c21-ee36-4fd4-b3e5-7efcd0b5d3d7" />
